### PR TITLE
opam var os on Windows is win32

### DIFF
--- a/tailwindcss.opam
+++ b/tailwindcss.opam
@@ -9,17 +9,17 @@ doc: "https://tmattio.github.io/opam-tailwindcss/"
 bug-reports: "https://github.com/tmattio/opam-tailwindcss/issues"
 dev-repo: "git+https://github.com/tmattio/opam-tailwindcss.git"
 build: []
-install: [ 
-  "cp" 
+install: [
+  "cp"
   "bin/tailwindcss-linux-arm64" {os = "linux" & arch = "arm64"}
   "bin/tailwindcss-linux-x64" {os = "linux" & arch = "x86_64"}
   "bin/tailwindcss-macos-arm64" {os = "macos" & arch = "arm64"}
   "bin/tailwindcss-macos-x64" {os = "macos" & arch = "x86_64"}
-  "bin/tailwindcss-windows-x64.exe" {os = "windows" & arch = "x86_64"}
+  "bin/tailwindcss-windows-x64.exe" {os = "win32" & arch = "x86_64"}
   "%{bin}%/tailwindcss"
 ]
 available: [
   ( (os = "linux" & (arch = "x86_64" | arch = "arm64"))
   | (os = "macos" & (arch = "x86_64" | arch = "arm64"))
-  | (os = "windows" &  arch = "x86_64"))
+  | (os = "win32" &  arch = "x86_64"))
 ]


### PR DESCRIPTION
Whitespace and permissions changes got in the mix.