### PR TITLE
Windows: install as tailwindcss.exe

### DIFF
--- a/dune
+++ b/dune
@@ -42,3 +42,8 @@
   (and
    (= %{architecture} amd64)
    (= %{os_type} Win32))))
+
+(rule
+ (alias runtest)
+ (action
+  (run tailwindcss --help)))

--- a/dune
+++ b/dune
@@ -37,8 +37,8 @@
 (install
  (section bin)
  (files
-  (bin/tailwindcss-macos-x64 as tailwindcss))
+  (bin/tailwindcss-windows-x64.exe as tailwindcss.exe))
  (enabled_if
   (and
    (= %{architecture} amd64)
-   (= %{system} windows))))
+   (= %{os_type} Win32))))

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.8)
-
+(lang dune 3.5)
 (name tailwindcss)
+(formatting (enabled_for dune))

--- a/tailwindcss.opam
+++ b/tailwindcss.opam
@@ -16,7 +16,8 @@ install: [
   "bin/tailwindcss-macos-arm64" {os = "macos" & arch = "arm64"}
   "bin/tailwindcss-macos-x64" {os = "macos" & arch = "x86_64"}
   "bin/tailwindcss-windows-x64.exe" {os = "win32" & arch = "x86_64"}
-  "%{bin}%/tailwindcss"
+  "%{bin}%/tailwindcss" {os != "win32"}
+  "%{bin}%/tailwindcss.exe" {os = "win32"}
 ]
 available: [
   ( (os = "linux" & (arch = "x86_64" | arch = "arm64"))


### PR DESCRIPTION
Fixes Dune error:
```
File "dune", line 12, characters 9-24:
12 |     (run tailwindcss -m -c %{config} -i %{input} -o %{target})))))
              ^^^^^^^^^^^
Error: Program tailwindcss not found in the tree or in PATH
 (context: default)
```